### PR TITLE
Do not lazy-load first item's images

### DIFF
--- a/src/main/handlebars/browse.handlebars
+++ b/src/main/handlebars/browse.handlebars
@@ -29,7 +29,7 @@
           </div>
           <div class="images size-{{size images}}">
             {{#each images}}
-              <img loading="lazy" src="/image/{{slug}}/thumb-{{.}}.webp" width="1024" onclick="lightbox.show(this)">
+              <img {{#unless ../@first}}loading="lazy"{{/unless}} src="/image/{{slug}}/thumb-{{.}}.webp" width="1024" onclick="lightbox.show(this)">
             {{/each}}
           </div>
 

--- a/src/main/handlebars/journey.handlebars
+++ b/src/main/handlebars/journey.handlebars
@@ -38,7 +38,7 @@
           </div>
           <div class="images size-{{size images}}">
             {{#each images}}
-              <img loading="lazy" src="/image/{{slug}}/thumb-{{.}}.webp" width="1024" onclick="lightbox.show(this)">
+              <img {{#unless ../@first}}loading="lazy"{{/unless}} src="/image/{{slug}}/thumb-{{.}}.webp" width="1024" onclick="lightbox.show(this)">
             {{/each}}
           </div>
 


### PR DESCRIPTION
Prevents this Lighthouse warning:

![image](https://user-images.githubusercontent.com/696742/190245607-3f82769a-5f0c-4cfa-a796-6c5b620ea845.png)

> Concretely, our analysis shows that more eagerly loading images within the initial viewport—while liberally lazy-loading the rest—can give us the best of both worlds:

Source: https://web.dev/lcp-lazy-loading/ /cc @kiesel