### PR TITLE
Aggregate coordinates from Google Maps links

### DIFF
--- a/src/main/handlebars/browse.handlebars
+++ b/src/main/handlebars/browse.handlebars
@@ -23,7 +23,7 @@
             {{../date date format="d.m.Y"}} @
             <ul class="locations" role="list">
               {{#each locations}}
-                <li><a href="{{link}}">{{name}}</a></li>
+                <li><a title="@{{lat}},{{lon}}" href="{{link}}">{{name}}</a></li>
               {{/each}}
             </ul>
           </div>

--- a/src/main/handlebars/journey.handlebars
+++ b/src/main/handlebars/journey.handlebars
@@ -13,7 +13,15 @@
           {{/each}}
         </ul>
       </div>
-      {{& journey.content}}
+      <div class="images overview size-{{size images}}">
+        {{#each journey.images}}
+          <img {{#unless ../@first}}loading="lazy"{{/unless}} src="/image/{{journey.slug}}/thumb-{{.}}.webp" width="1024" onclick="lightbox.show(this)">
+        {{/each}}
+      </div>
+
+      <div class="content">
+        {{& journey.content}}
+      </div>
 
       <ul class="summary">
         {{#each itinerary}}

--- a/src/main/handlebars/journey.handlebars
+++ b/src/main/handlebars/journey.handlebars
@@ -9,7 +9,7 @@
         {{date journey.is.from format="d.m.Y"}} - {{date journey.is.until format="d.m.Y"}} @
         <ul class="locations" role="list">
           {{#each journey.locations}}
-            <li><a href="{{link}}">{{name}}</a></li>
+            <li><a title="@{{lat}},{{lon}}" href="{{link}}">{{name}}</a></li>
           {{/each}}
         </ul>
       </div>

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -171,6 +171,10 @@
       grid-template-columns: 1fr;
     }
 
+    .images.overview {
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+    }
+
     .images img {
       aspect-ratio: 15 / 10;
       object-fit: cover;
@@ -249,6 +253,10 @@
     @media (max-width: 767px) {
       .images {
         grid-template-columns: 1fr;
+      }
+
+      .images.overview {
+        grid-template-columns: 1fr 1fr;
       }
     }
 

--- a/src/main/php/de/thekid/dialog/import/LocalDirectory.php
+++ b/src/main/php/de/thekid/dialog/import/LocalDirectory.php
@@ -45,13 +45,13 @@ class LocalDirectory extends Command {
       // Aggregate coordinates from Google Maps links
       foreach ($item['locations'] as &$location) {
         $r= new HttpConnection($location['link'])->get();
-        if (!preg_match('#/maps/place/[^/]+/@([0-9.-]+),([0-9.-]+),([0-9]+)z#', $r->header('Location')[0], $m)) {
+        if (!preg_match('#/maps/place/[^/]+/@([0-9.-]+),([0-9.-]+),([0-9.]+)z#', $r->header('Location')[0], $m)) {
           throw new FormatException('Cannot resolve '.$location['link'].': '.$r->toString());
         }
 
         $location['lat']= (float)$m[1];
         $location['lon']= (float)$m[2];
-        $location['zoom']= (int)$m[3];
+        $location['zoom']= (float)$m[3];
       }
 
       $r= $this->api->resource('entries/{0}', [$item['slug']])->put($item, 'application/json');


### PR DESCRIPTION
This PR aggregates latitute, longitude and zoom factor from Google Maps links. This is done by fetching the redirect location and matching the information from it:

```bash
$ curl -si 'https://goo.gl/maps/mnsteNxpf9iPAmEq6' | grep ^location
location: https://www.google.de/maps/place/Norway/@64.2867183,8.7810941,5z/data=...?shorturl=1
#                                          ^^^^^^  ^^^^^^^^^^ ^^^^^^^^^ ^
#                                          Name    Latitude   Longitude Zoom
```

These could be used to draw markers onto an embedded map.