### PR TITLE
Add robots.txt

### DIFF
--- a/src/main/php/de/thekid/dialog/App.php
+++ b/src/main/php/de/thekid/dialog/App.php
@@ -32,13 +32,14 @@ class App extends Application {
     $manifest= new AssetsManifest($this->environment->path('src/main/webapp/assets/manifest.json'));
     $static= ['Cache-Control' => 'max-age=604800'];
     return [
-      '/image'  => new FilesFrom($this->environment->arguments()[0])->with($static),
-      '/static' => new FilesFrom($this->environment->path('src/main/webapp'))->with($static),
-      '/assets' => new AssetsFrom($this->environment->path('src/main/webapp'))->with(fn($file) => [
+      '/image'      => new FilesFrom($this->environment->arguments()[0])->with($static),
+      '/static'     => new FilesFrom($this->environment->path('src/main/webapp'))->with($static),
+      '/assets'     => new AssetsFrom($this->environment->path('src/main/webapp'))->with(fn($file) => [
         'Cache-Control' => $manifest->immutable($file) ?? 'max-age=604800, must-revalidate'
       ]),
-      '/api'    => $auth->optional(new RestApi(new ResourcesIn('de.thekid.dialog.api', $new))),
-      '/'       => new Frontend(
+      '/robots.txt' => fn($req, $res) => $res->send("User-agent: *\nDisallow: /api/\n", 'text/plain'),
+      '/api'        => $auth->optional(new RestApi(new ResourcesIn('de.thekid.dialog.api', $new))),
+      '/'           => new Frontend(
         new HandlersIn('de.thekid.dialog.web', $new),
         new Handlebars($this->environment->path('src/main/handlebars'), [
           new Dates(TimeZone::getByName('Europe/Berlin')),


### PR DESCRIPTION
Prevents 404s. Also tells bots to leave their fingers from /api, which will not contain anything useful for indexing.

```bash
$ curl -i https://dialog.sloppy.zone/robots.txt
HTTP/2 200
date: Mon, 24 Oct 2022 21:10:29 GMT
server: XP
content-type: text/plain
content-length: 30
strict-transport-security: max-age=15768000

User-agent: *
Disallow: /api/
```

### See also

* https://developers.google.com/search/docs/crawling-indexing/robots/intro
* https://www.cloudflare.com/robots.txt