### PR TITLE
Read configuration from config.ini if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ $ db.users.insert({handle: "import", pass: "4323135e32ac4..."});
 # ...
 ```
 
+Store the connection string in a configuration file named *config.ini*:
+
+```ini
+[mongo]
+uri=mongodb+srv://[USER]:[PASSWORD]@[PROJECT].[ORG].mongodb.net
+```
+
 Then, run composer to install PHP and JavaScript dependencies.
 
 ```bash
@@ -40,7 +47,6 @@ $ composer up
 Now, Dialog can be run locally.
 
 ```bash
-$ export MONGO_URI=mongodb+srv://[USER]:[PASSWORD]@[PROJECT].[ORG].mongodb.net
 $ xp serve
 # ...
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Store the connection string in a configuration file named *config.ini*:
 
 ```ini
 [mongo]
-uri=mongodb+srv://[USER]:[PASSWORD]@[PROJECT].[ORG].mongodb.net
+uri=mongodb+srv://[USER]:[PASSWORD]@[PROJECT].[ORG].mongodb.net/?readPreference=nearest
 ```
 
 Then, run composer to install PHP and JavaScript dependencies.

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
   },
 
   "scripts": {
-    "dev": "xp -supervise web -p dev -m develop -a 0.0.0.0:8080 de.thekid.dialog.App ./import",
-    "serve": "xp -supervise web -p dev -a 0.0.0.0:8080 de.thekid.dialog.App ./import",
+    "dev": "xp -supervise web -c . -p dev -m develop -a 0.0.0.0:8080 de.thekid.dialog.App ./import",
+    "serve": "xp -supervise web -c . -p dev -a 0.0.0.0:8080 de.thekid.dialog.App ./import",
     "import": "xp cmd de.thekid.dialog.import.LocalDirectory",
     "post-update-cmd": "xp bundle -m src/main/webapp/assets/manifest.json src/main/webapp/assets/"
   }

--- a/src/main/php/de/thekid/dialog/App.php
+++ b/src/main/php/de/thekid/dialog/App.php
@@ -33,7 +33,7 @@ class App extends Application {
     $manifest= new AssetsManifest($this->environment->path('src/main/webapp/assets/manifest.json'));
     $static= ['Cache-Control' => 'max-age=604800'];
     return [
-      '/image'      => new FilesFrom($this->environment->arguments()[0])->with($static),
+      '/image'      => new FilesFrom($storage)->with($static),
       '/static'     => new FilesFrom($this->environment->path('src/main/webapp'))->with($static),
       '/assets'     => new AssetsFrom($this->environment->path('src/main/webapp'))->with(fn($file) => [
         'Cache-Control' => $manifest->immutable($file) ?? 'max-age=604800, must-revalidate'

--- a/src/main/php/de/thekid/dialog/App.php
+++ b/src/main/php/de/thekid/dialog/App.php
@@ -15,8 +15,9 @@ class App extends Application {
 
   /** Returns routing for this web application */
   public function routes() {
-    $conn= new MongoConnection($this->environment->variable('MONGO_URI'));
-    $repository= new Repository($conn->database($this->environment->variable('MONGO_DB') ?? 'dialog'));
+    $preferences= new Preferences($this->environment, 'config');
+    $conn= new MongoConnection($preferences->get('mongo', 'uri'));
+    $repository= new Repository($conn->database($preferences->optional('mongo', 'db', 'dialog')));
     $storage= new Path($this->environment->arguments()[0]);
     $new= fn($class) => $class->newInstance($repository, $storage);
 

--- a/src/main/php/de/thekid/dialog/Preferences.php
+++ b/src/main/php/de/thekid/dialog/Preferences.php
@@ -1,0 +1,49 @@
+<?php namespace de\thekid\dialog;
+
+use util\NoSuchElementException;
+use web\Environment;
+
+/** @test de.thekid.dialog.unittest.PreferencesTest */
+class Preferences {
+  private $sources;
+
+  /** Creates a new Preferences instances from an environment and a config file name */
+  public function __construct(Environment $env, string $config) {
+    $this->sources= ['env' => fn($section, $name) => $env->variable(strtoupper("{$section}_{$name}"))];
+
+    $prop= $env->properties($config);
+    if ($prop->exists()) {
+      $this->sources['config']= fn($section, $name) => $prop->readString($section, $name, null);
+    }
+  }
+
+  /**
+   * Gets a configuration value. Throws an exception if the value is
+   * absent.
+   *
+   * @throws util.NoSuchElementException
+   */
+  public function get(string $section, string $name): string {
+    foreach ($this->sources as $read) {
+      if (null !== ($value= $read($section, $name))) return $value;
+    }
+
+    throw new NoSuchElementException(sprintf(
+      'Missing configuration value <%s::%s> in %s',
+      $section,
+      $name,
+      implode(', ', array_keys($this->sources)),
+    ));
+  }
+
+  /**
+   * Gets a configuration value. Returns a given default (or NULL) if
+   * the value is absent.
+   */
+  public function optional(string $section, string $name, ?string $default= null): ?string {
+    foreach ($this->sources as $read) {
+      if (null !== ($value= $read($section, $name))) return $value;
+    }
+    return $default;
+  }
+}

--- a/src/main/php/de/thekid/dialog/Preferences.php
+++ b/src/main/php/de/thekid/dialog/Preferences.php
@@ -11,10 +11,9 @@ class Preferences {
   public function __construct(Environment $env, string $config) {
     $this->sources= ['env' => fn($section, $name) => $env->variable(strtoupper("{$section}_{$name}"))];
 
+    // If the properties file exists, use it as secondary source
     $prop= $env->properties($config);
-    if ($prop->exists()) {
-      $this->sources['config']= $prop->readString(...);
-    }
+    $prop->exists() && $this->sources['config']= $prop->readString(...);
   }
 
   /**

--- a/src/main/php/de/thekid/dialog/Preferences.php
+++ b/src/main/php/de/thekid/dialog/Preferences.php
@@ -13,7 +13,7 @@ class Preferences {
 
     $prop= $env->properties($config);
     if ($prop->exists()) {
-      $this->sources['config']= fn($section, $name) => $prop->readString($section, $name, null);
+      $this->sources['config']= $prop->readString(...);
     }
   }
 

--- a/src/test/php/de/thekid/dialog/unittest/PreferencesTest.php
+++ b/src/test/php/de/thekid/dialog/unittest/PreferencesTest.php
@@ -1,0 +1,86 @@
+<?php namespace de\thekid\dialog\unittest;
+
+use de\thekid\dialog\Preferences;
+use unittest\{Assert, Before, Expect, Test, Values};
+use util\NoSuchElementException;
+use util\{Properties, RegisteredPropertySource};
+use web\Environment;
+
+class PreferencesTest {
+  private $config, $environment;
+
+  #[Before]
+  public function environment() {
+    $this->config= new class('testing') extends Properties {
+      public function use($sections) { $this->_data= $sections; }
+      public function exists(): bool { return null !== $this->_data; }
+    };
+
+    $source= new RegisteredPropertySource('config', $this->config);
+    $this->environment= new class('test', '.', '.', [$source], [], []) extends Environment {
+      private $variables;
+
+      public function export($variables) {
+        $this->variables= $variables;
+        return $this;
+      }
+
+      public function variable($name) {
+        return $this->variables[$name] ?? null;
+      }
+    };
+  }
+
+  #[Test]
+  public function can_create() {
+    new Preferences($this->environment, 'config');
+  }
+
+  #[Test, Values(['get', 'optional'])]
+  public function uses_environment($op) {
+    $this->config->use(null);
+    $fixture= new Preferences($this->environment->export(['MONGO_URI' => 'set']), 'config');
+
+    Assert::equals('set', $fixture->{$op}('mongo', 'uri'));
+  }
+
+  #[Test, Values(['get', 'optional'])]
+  public function uses_properties($op) {
+    $this->config->use(['mongo' => ['uri' => 'configured']]);
+    $fixture= new Preferences($this->environment->export([]), 'config');
+
+    Assert::equals('configured', $fixture->{$op}('mongo', 'uri'));
+  }
+
+  #[Test, Values(['get', 'optional'])]
+  public function environment_has_precedence_over_configuration($op) {
+    $this->config->use(['mongo' => ['uri' => 'configured']]);
+    $fixture= new Preferences($this->environment->export(['MONGO_URI' => 'set']), 'config');
+
+    Assert::equals('set', $fixture->{$op}('mongo', 'uri'));
+  }
+
+  #[Test, Expect(class: NoSuchElementException::class, withMessage: '/Missing.+mongo::uri/')]
+  public function get_raises_exception_if_not_found() {
+    $this->config->use(null);
+    $fixture= new Preferences($this->environment->export([]), 'config');
+
+    $fixture->get('mongo', 'uri');
+  }
+
+  #[Test]
+  public function optional_returns_null_if_not_found() {
+    $this->config->use(null);
+    $fixture= new Preferences($this->environment->export([]), 'config');
+
+    Assert::null($fixture->optional('mongo', 'uri'));
+  }
+
+  #[Test]
+  public function optional_can_return_default_if_not_found() {
+    $this->config->use(null);
+    $fixture= new Preferences($this->environment->export([]), 'config');
+
+    Assert::equals('default', $fixture->optional('mongo', 'uri', 'default'));
+  }
+}


### PR DESCRIPTION
Example:

```ini
[mongo]
uri=mongodb+srv://user:pass@dialog.id.mongodb.net/?readPreference=nearest
db=prototype
```

Preparation work for #27