### PR TITLE
Change lightbox to use HTML <dialog> element

### DIFF
--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -613,7 +613,7 @@
       transition: transform ease-in-out 70ms;
     }
 
-    #lightbox img:hover + .meta {
+    #lightbox img:hover ~ .meta {
       transform: scale(1, 1);
     }
 
@@ -629,27 +629,6 @@
 
     #lightbox .meta div:where(:last-child) {
       border-top-right-radius: .25rem;
-    }
-
-    #lightbox i {
-      position: absolute;
-      top: .5rem;
-      right: .5rem;
-      background-color: #444;
-      width: 2rem;
-      height: 2rem;
-      border-radius: 50%;
-      border: 1px solid #666;
-      text-decoration: none;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: white;
-      padding-top: 6px;
-      font-size: 1.75rem;
-      font-style: normal;
-      font-weight: 400;
-      cursor: pointer;
     }
 
     footer {
@@ -746,7 +725,6 @@
   </main>
 
   <dialog id="lightbox">
-    <i>×</i>
     <div class="image">
       <img alt="Lightbox" width="100%">
       <div class="meta">

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -577,7 +577,7 @@
       background-color: transparent;
     }
 
-    #lightbox[open]::backdrop {
+    #lightbox::backdrop {
       -webkit-backdrop-filter: blur(10px) brightness(.5);
       backdrop-filter: blur(10px) brightness(.5);
     }

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -661,17 +661,19 @@
 
     @media (max-width: 619px) {
       #lightbox {
-        padding: 0;
+        margin-left: 0;
+        margin-right: 0;
+        max-width: 100%;
       }
 
       #lightbox .meta {
-        bottom: auto;
         grid-template-columns: repeat(3, max-content) 1fr;
         transform: scale(1, 1);
         gap: 0;
         background-color: white;
         border: none;
         border-radius: 0;
+        position: unset;
       }
 
       #lightbox img {

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -565,7 +565,6 @@
 
     #lightbox {
       position: fixed;
-      z-index: 999;
       inset: 0;
       display: flex;
       align-items: center;
@@ -573,12 +572,17 @@
       border: 1px solid #444;
       transform: scale(0, 0);
       transition: transform ease-in-out 300ms;
-      -webkit-backdrop-filter: blur(10px) brightness(.5);
-      backdrop-filter: blur(10px) brightness(.5);
-      padding: .5rem;
+      padding: 0;
+      border: none;
+      background-color: transparent;
     }
 
-    #lightbox.open {
+    #lightbox[open]::backdrop {
+      -webkit-backdrop-filter: blur(10px) brightness(.5);
+      backdrop-filter: blur(10px) brightness(.5);
+    }
+
+    #lightbox[open] {
       transform: scale(1, 1);
     }
 
@@ -741,7 +745,7 @@
     </div>
   </main>
 
-  <div id="lightbox">
+  <dialog id="lightbox">
     <i>×</i>
     <div class="image">
       <img alt="Lightbox" width="100%">
@@ -754,7 +758,7 @@
         <div><output name="exposuretime"></output> s</div>
       </div>
     </div>
-  </div>
+  </dialog>
 
   <footer class="footer">
     With ❤️ by Timm Friebe 2005-{{date null format="Y"}}

--- a/src/main/js/lightbox.js
+++ b/src/main/js/lightbox.js
@@ -4,7 +4,7 @@ class Lightbox {
   #open($target, $link) {
     const $full = $target.querySelector('img');
     $full.src = '';
-    $target.classList.add('open');
+    $target.showModal();
     $full.src = $link.href;
 
     // Overlay meta data if present
@@ -18,21 +18,9 @@ class Lightbox {
     }
   }
 
-  /** Closes the given lightbox */
-  #close($target) {
-    $target.classList.remove('open');
-  }
-
   /** Attach all of the given elements to open the lightbox specified by the given DOM element */
   attach(selector, $target) {
-    document.addEventListener('keydown', e => {
-      if ('Escape' === e.key) this.#close($target);
-    });
-
-    $target.addEventListener('click', e => {
-      this.#close($target);
-    });
-
+    $target.addEventListener('click', e => $target.close());
     selector.forEach($link => $link.addEventListener('click', e => {
       e.preventDefault();
       this.#open($target, $link);


### PR DESCRIPTION
Implements #31 and uses the [`<dialog>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) and the associated JavaScript APIs instead of a regular div. This simplifies the code, e.g. because by default, a dialog invoked by the *showModal()* method will allow for its dismissal by the `Escape`. 

## Browser support

Looks good:

* [x] [Dialog](https://caniuse.com/?search=dialog) 
* [x] [Backdrop](https://caniuse.com/mdn-css_selectors_backdrop_dialog)

## See also

https://css-tricks.com/almanac/selectors/b/backdrop/