### PR TITLE
Collect statistics on views

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "xp-forge/frontend": "^4.0",
     "xp-forge/rest-api": "^3.4",
     "xp-forge/rest-client": "^5.3",
-    "xp-forge/handlebars-templates": "^2.1",
+    "xp-forge/handlebars-templates": "^2.2",
     "xp-forge/markdown": "^6.0",
     "xp-forge/yaml": "^6.0",
     "xp-forge/hashing": "^2.1",

--- a/src/main/handlebars/content.handlebars
+++ b/src/main/handlebars/content.handlebars
@@ -23,6 +23,7 @@ parent: feed
             <li><a title="@{{lat}},{{lon}}" href="{{link}}">{{name}}</a></li>
           {{/each}}
         </ul>
+        {{count item.views '' '(Eine Ansicht)' ' (# Ansichten)'}}
       </div>
 
       <div id="map">

--- a/src/main/handlebars/content.handlebars
+++ b/src/main/handlebars/content.handlebars
@@ -46,6 +46,11 @@ parent: feed
       {{/each}}
 
       mapping.project(document.querySelector('#map'));
+
+      // Update statistics
+      window.setTimeout(() => {
+        fetch('/api/statistics/{{item.slug}}', {method: 'POST', body: '{{sign item.slug}}'});
+      }, 5000);
     </script>
   {{/inline}}
 {{/layout}}

--- a/src/main/handlebars/content.handlebars
+++ b/src/main/handlebars/content.handlebars
@@ -23,7 +23,7 @@ parent: feed
             <li><a title="@{{lat}},{{lon}}" href="{{link}}">{{name}}</a></li>
           {{/each}}
         </ul>
-        {{count item.views '' '(Eine Ansicht)' ' (# Ansichten)'}}
+        {{count item.views '' '(Eine Ansicht)' '(# Ansichten)'}}
       </div>
 
       <div id="map">

--- a/src/main/handlebars/content.handlebars
+++ b/src/main/handlebars/content.handlebars
@@ -51,7 +51,7 @@ parent: feed
       // Update statistics
       window.setTimeout(() => {
         fetch('/api/statistics/{{item.slug}}', {method: 'POST', body: '{{sign item.slug}}'});
-      }, 5000);
+      }, Math.min({{size item.images}} * 1500, 5000));
     </script>
   {{/inline}}
 {{/layout}}

--- a/src/main/handlebars/feed.handlebars
+++ b/src/main/handlebars/feed.handlebars
@@ -31,6 +31,7 @@
                 <li><a title="@{{lat}},{{lon}}" href="{{link}}">{{name}}</a></li>
               {{/each}}
             </ul>
+            {{#with views}} {{count . '' '(Eine Ansicht)' ' (# Ansichten)'}}{{/with}}
           </div>
 
           {{> partials/images in=. first=@first}}

--- a/src/main/handlebars/feed.handlebars
+++ b/src/main/handlebars/feed.handlebars
@@ -31,7 +31,7 @@
                 <li><a title="@{{lat}},{{lon}}" href="{{link}}">{{name}}</a></li>
               {{/each}}
             </ul>
-            {{#with views}} {{count . '' '(Eine Ansicht)' ' (# Ansichten)'}}{{/with}}
+            {{count views '' '(Eine Ansicht)' ' (# Ansichten)'}}
           </div>
 
           {{> partials/images in=. first=@first}}

--- a/src/main/handlebars/feed.handlebars
+++ b/src/main/handlebars/feed.handlebars
@@ -31,7 +31,7 @@
                 <li><a title="@{{lat}},{{lon}}" href="{{link}}">{{name}}</a></li>
               {{/each}}
             </ul>
-            {{count views '' '(Eine Ansicht)' ' (# Ansichten)'}}
+            {{count views '' '(Eine Ansicht)' '(# Ansichten)'}}
           </div>
 
           {{> partials/images in=. first=@first}}

--- a/src/main/handlebars/journey.handlebars
+++ b/src/main/handlebars/journey.handlebars
@@ -24,7 +24,7 @@ parent: feed
             <li><a title="@{{lat}},{{lon}}" href="{{link}}">{{name}}</a></li>
           {{/each}}
         </ul>
-        {{count journey.views '' '(Eine Ansicht)' ' (# Ansichten)'}}
+        {{count journey.views '' '(Eine Ansicht)' '(# Ansichten)'}}
       </div>
       {{> partials/images in=journey first='true' style='overview'}}
 

--- a/src/main/handlebars/journey.handlebars
+++ b/src/main/handlebars/journey.handlebars
@@ -88,6 +88,11 @@ parent: feed
       {{/each}}
 
       mapping.project(document.querySelector('#map'));
+
+      // Update statistics
+      window.setTimeout(() => {
+        fetch('/api/statistics/{{journey.slug}}', {method: 'POST', body: '{{sign journey.slug}}'});
+      }, 10000);
     </script>
   {{/inline}}
 {{/layout}}

--- a/src/main/handlebars/journey.handlebars
+++ b/src/main/handlebars/journey.handlebars
@@ -24,6 +24,7 @@ parent: feed
             <li><a title="@{{lat}},{{lon}}" href="{{link}}">{{name}}</a></li>
           {{/each}}
         </ul>
+        {{count journey.views '' '(Eine Ansicht)' ' (# Ansichten)'}}
       </div>
       {{> partials/images in=journey first='true' style='overview'}}
 

--- a/src/main/php/de/thekid/dialog/Helpers.php
+++ b/src/main/php/de/thekid/dialog/Helpers.php
@@ -13,6 +13,8 @@ use web\frontend\helpers\Extension;
  */ 
 class Helpers extends Extension {
 
+  public function __construct(private ?Signing $signing= null) { }
+
   /** @return iterable */
   public function helpers() {
     yield 'range' => function($node, $context, $options) {
@@ -36,6 +38,9 @@ class Helpers extends Extension {
         is_scalar($value) && $r.= ' data-'.htmlspecialchars($key).'="'.htmlspecialchars($value).'"';
       }
       return $r;
+    };
+    yield 'sign' => function($node, $context, $options) {
+      return $this->signing?->sign($options[0]);
     };
   }
 }

--- a/src/main/php/de/thekid/dialog/Signing.php
+++ b/src/main/php/de/thekid/dialog/Signing.php
@@ -1,0 +1,34 @@
+<?php namespace de\thekid\dialog;
+
+use text\hash\{Algorithm, Hashing};
+use util\Secret;
+
+/** @test de.thekid.dialog.unittest.SigningTest */
+class Signing {
+  private $tolerance= 10;
+
+  public function __construct(private Secret $secret, private Algorithm $hashing= Hashing::sha256()) { }
+
+  /** Uses a tolerance of a given amount of seconds */
+  public function tolerating(int $seconds): self {
+    $this->tolerance= $seconds;
+    return $this;
+  }
+
+  /** Sign a given input string and return the signature parameter's value */
+  public function sign(string $input, ?int $time= null): string {
+    return sprintf(
+      '%s.%d',
+      $this->hashing->digest($input.$this->secret->reveal())->hex(),
+      $time ?? time()
+    );
+  }
+
+  /** Verify a given signature is valid for a given input string */
+  public function verify(string $input, string $signature, ?int $time= null): bool {
+    sscanf($signature, '%[^.].%d', $digest, $from);
+    $equals= $this->hashing->digest($input.$this->secret->reveal())->equals($digest);
+    $active= abs(($time ?? time()) - $from) <= $this->tolerance;
+    return $equals && $active;
+  }
+}

--- a/src/main/php/de/thekid/dialog/Signing.php
+++ b/src/main/php/de/thekid/dialog/Signing.php
@@ -17,17 +17,18 @@ class Signing {
 
   /** Sign a given input string and return the signature parameter's value */
   public function sign(string $input, ?int $time= null): string {
+    $time??= time();
     return sprintf(
       '%s.%d',
-      $this->hashing->digest($input.$this->secret->reveal())->hex(),
-      $time ?? time()
+      $this->hashing->digest($input.$time.$this->secret->reveal())->hex(),
+      $time
     );
   }
 
   /** Verify a given signature is valid for a given input string */
   public function verify(string $input, string $signature, ?int $time= null): bool {
     sscanf($signature, '%[^.].%d', $digest, $from);
-    $equals= $this->hashing->digest($input.$this->secret->reveal())->equals($digest);
+    $equals= $this->hashing->digest($input.$from.$this->secret->reveal())->equals($digest);
     $active= abs(($time ?? time()) - $from) <= $this->tolerance;
     return $equals && $active;
   }

--- a/src/main/php/de/thekid/dialog/api/Statistics.php
+++ b/src/main/php/de/thekid/dialog/api/Statistics.php
@@ -17,7 +17,7 @@ class Statistics {
   public function update(string $id, #[Body] $signature) {
     return $this->signing->verify($id, $signature)
       ? $this->repository->modify($id, ['$inc' => ['views' => 1]])->modified()
-      : 0
+      : 0 // Silently ignore invalid requests
     ;
   }
 }

--- a/src/main/php/de/thekid/dialog/api/Statistics.php
+++ b/src/main/php/de/thekid/dialog/api/Statistics.php
@@ -1,0 +1,23 @@
+<?php namespace de\thekid\dialog\api;
+
+use de\thekid\dialog\{Repository, Signing};
+use io\Path;
+use web\rest\{Post, Resource, Body};
+
+#[Resource('/api/statistics')]
+class Statistics {
+
+  public function __construct(
+    private Repository $repository,
+    private Path $storage,
+    private Signing $signing
+  ) { }
+
+  #[Post('/{id:.+(/.+)?}')]
+  public function update(string $id, #[Body] $signature) {
+    return $this->signing->verify($id, $signature)
+      ? $this->repository->modify($id, ['$inc' => ['views' => 1]])->modified()
+      : 0
+    ;
+  }
+}

--- a/src/main/php/de/thekid/dialog/web/Home.php
+++ b/src/main/php/de/thekid/dialog/web/Home.php
@@ -1,7 +1,7 @@
 <?php namespace de\thekid\dialog\web;
 
 use de\thekid\dialog\Repository;
-use web\frontend\{Handler, Get, View};
+use web\frontend\{Handler, Get, Head, View};
 
 #[Handler('/')]
 class Home {

--- a/src/test/php/de/thekid/dialog/unittest/SigningTest.php
+++ b/src/test/php/de/thekid/dialog/unittest/SigningTest.php
@@ -53,6 +53,15 @@ class SigningTest {
     Assert::false($s->verify($query, $signature));
   }
 
+  #[Test]
+  public function fiddling_with_time() {
+    $s= new Signing($this->secret);
+    $query= 'target=test';
+
+    [$hash, $time]= explode('.', $s->sign($query));
+    Assert::false($s->verify($query, sprintf('%s.%d', $hash, $time + 1)));
+  }
+
   #[Test, Values([-3600, -1, 1, 3600])]
   public function cannot_verify_links_after_expiration_window($window) {
     $s= new Signing($this->secret)->tolerating(0);

--- a/src/test/php/de/thekid/dialog/unittest/SigningTest.php
+++ b/src/test/php/de/thekid/dialog/unittest/SigningTest.php
@@ -1,0 +1,48 @@
+<?php namespace de\thekid\dialog\unittest;
+
+use de\thekid\dialog\Signing;
+use text\hash\Hashing;
+use unittest\{Assert, Before, Test};
+use util\Secret;
+
+class SigningTest {
+  private const TEST_TIME= 1668365788;
+  private $secret= new Secret('test');
+
+  #[Test]
+  public function can_create() {
+    new Signing($this->secret);
+  }
+
+  #[Test]
+  public function can_create_with_hashing() {
+    new Signing($this->secret, Hashing::sha256());
+  }
+
+  #[Test]
+  public function sign_and_verify() {
+    $s= new Signing($this->secret);
+    $query= 'target=test';
+
+    $signature= $s->sign($query);
+    Assert::true($s->verify($query, $signature));
+  }
+
+  #[Test, Values([-3600, -1, 1, 3600])]
+  public function cannot_verify_links_after_expiration_window($window) {
+    $s= new Signing($this->secret)->tolerating(0);
+    $query= 'target=test';
+
+    $signature= $s->sign($query, time: self::TEST_TIME);
+    Assert::false($s->verify($query, $signature, time: self::TEST_TIME + $window));
+  }
+
+  #[Test, Values([-10, -1, 0, 1, 10])]
+  public function verify_links_within_expiration_window($window) {
+    $s= new Signing($this->secret)->tolerating(10);
+    $query= 'target=test';
+
+    $signature= $s->sign($query, time: self::TEST_TIME);
+    Assert::true($s->verify($query, $signature, time: self::TEST_TIME + $window));
+  }
+}

--- a/src/test/php/de/thekid/dialog/unittest/SigningTest.php
+++ b/src/test/php/de/thekid/dialog/unittest/SigningTest.php
@@ -28,6 +28,31 @@ class SigningTest {
     Assert::true($s->verify($query, $signature));
   }
 
+  #[Test]
+  public function does_not_verify_empty_signature() {
+    $s= new Signing($this->secret);
+
+    Assert::false($s->verify('target=test', ''));
+  }
+
+  #[Test]
+  public function does_not_verify_differing_query() {
+    $s= new Signing($this->secret);
+
+    $signature= $s->sign('target=test');
+    Assert::false($s->verify('target=other', $signature));
+  }
+
+  #[Test]
+  public function does_not_verify_differing_signature() {
+    $s= new Signing($this->secret);
+    $query= 'target=test';
+
+    $signature= $s->sign($query);
+    [$signature[0], $signature[1]]= [$signature[1], $signature[0]];
+    Assert::false($s->verify($query, $signature));
+  }
+
   #[Test, Values([-3600, -1, 1, 3600])]
   public function cannot_verify_links_after_expiration_window($window) {
     $s= new Signing($this->secret)->tolerating(0);


### PR DESCRIPTION
This PR collects sum of views on content and journey entries, and displays them in the feed. 

## Measurement

For a view to be counted:

* The user must have been on a journey page for 10 seconds
* The user must have been on a content page with:
  * 1 image: for 1.5 seconds
  * 2 images: for 3 seconds
  * 3 images: for 4.5 seconds
  * 4 and more images: for 5 seconds

This is implemented via `window.setTimeout()` - this will exclude search engine bots, which would (to my knowledge) not execute that.

Every view is counted, refreshing a page and waiting for the above time span will increase the counter one more.

## Visualization

No views yet:
<img width="338" alt="image" src="https://user-images.githubusercontent.com/696742/201542112-8b98a81a-60f3-4599-a4a3-34c2afc4712c.png">

One view:
<img width="304" alt="image" src="https://user-images.githubusercontent.com/696742/201542099-0c5d27bf-777d-41b1-b729-cf8b9c73dc6b.png">

More than one view:
<img width="234" alt="image" src="https://user-images.githubusercontent.com/696742/201542125-b4cef7bf-7abe-472f-82a9-bdec15fde780.png">
