### PR TITLE
Select preview image from latest child element if none available

### DIFF
--- a/src/main/handlebars/home.handlebars
+++ b/src/main/handlebars/home.handlebars
@@ -32,7 +32,7 @@
         {{#if @last}}
           <div class="continue card">
             <a title="Seite 2" href="/feed?page=2">
-              {{#with images.0}}<img alt="{{title}}, {{date meta.dateTime format='d.m.Y H:i'}}" src="/image/{{slug}}/thumb-{{.}}.webp">{{else}}<div class="without-preview"></div>{{/with}}
+              {{#with preview}}<img alt="{{title}}, {{date meta.dateTime format='d.m.Y H:i'}}" src="/image/{{slug}}/thumb-{{name}}.webp">{{else}}<div class="without-preview"></div>{{/with}}
               <div class="next">&#187;</div>
             </a>
           </div>
@@ -45,7 +45,7 @@
               <div class="date">{{range is.from is.until format="M Y"}}</div>
               <a title="{{title}}" href="/journey/{{slug}}">
             {{/if}}
-              {{#with images.0}}<img alt="{{title}}, {{date meta.dateTime format='d.m.Y H:i'}}" src="/image/{{slug}}/thumb-{{.}}.webp">{{else}}<div class="without-preview"></div>{{/with}}
+              {{#with preview}}<img alt="{{title}}, {{date meta.dateTime format='d.m.Y H:i'}}" src="/image/{{slug}}/thumb-{{name}}.webp">{{else}}<div class="without-preview"></div>{{/with}}
               <h3>{{title}}</h3>
             </a>
           </div>

--- a/src/main/handlebars/journeys.handlebars
+++ b/src/main/handlebars/journeys.handlebars
@@ -20,7 +20,7 @@
         <div class="card">
           <div class="date">{{range is.from is.until format="M Y"}}</div>
           <a title="{{title}}" href="/journey/{{slug}}">
-            {{#with images.0}}<img alt="{{title}}, {{date meta.dateTime format='d.m.Y H:i'}}" {{#unless (top 3 @index)}}loading="lazy"{{/unless}} src="/image/{{slug}}/thumb-{{.}}.webp">{{else}}<div class="without-preview"></div>{{/with}}
+            {{#with preview}}<img alt="{{title}}, {{date meta.dateTime format='d.m.Y H:i'}}" {{#unless (top 3 @index)}}loading="lazy"{{/unless}} src="/image/{{slug}}/thumb-{{name}}.webp">{{else}}<div class="without-preview"></div>{{/with}}
             <h3>{{title}}</h3>
           </a>
         </div>

--- a/src/main/php/de/thekid/dialog/Repository.php
+++ b/src/main/php/de/thekid/dialog/Repository.php
@@ -1,6 +1,6 @@
 <?php namespace de\thekid\dialog;
 
-use com\mongodb\result\Update;
+use com\mongodb\result\{Cursor, Update};
 use com\mongodb\{Database, Document};
 use text\hash\Hashing;
 use util\{Date, Secret};
@@ -122,14 +122,13 @@ class Repository {
     return $cursor->first();
   }
 
-  /** Returns an entry's children */
-  public function children(string $slug): array<Document> {
-    $cursor= $this->database->collection('entries')->aggregate([
+  /** Returns an entry's children, latest first */
+  public function children(string $slug): Cursor {
+    return $this->database->collection('entries')->aggregate([
       ['$match' => ['parent' => ['$eq' => $slug], 'published' => ['$lt' => Date::now()]]],
       ['$unset' => '_searchable'],
       ['$sort'  => ['date' => -1]],
     ]);
-    return $cursor->all();
   }
 
   /** Replace an entry identified by a given slug with a given entity */

--- a/src/main/php/de/thekid/dialog/api/Entries.php
+++ b/src/main/php/de/thekid/dialog/api/Entries.php
@@ -109,8 +109,8 @@ class Entries {
     // time new content is added.
     $entry= $this->repository->entry($id, published: false);
     if (empty($entry['images'])) {
-      $first= $this->repository->children($id)->first();
-      $preview= empty($first['images']) ? null : ['slug' => $first['slug'], ...$first['images'][0]];
+      $latest= $this->repository->children($id)->first();
+      $preview= empty($latest['images']) ? null : ['slug' => $latest['slug'], ...$latest['images'][0]];
     } else {
       $preview= ['slug' => $id, ...$entry['images'][0]];
     }

--- a/src/main/php/de/thekid/dialog/api/Entries.php
+++ b/src/main/php/de/thekid/dialog/api/Entries.php
@@ -103,7 +103,18 @@ class Entries {
 
   #[Put('/{id:.+(/.+)?}/published')]
   public function publish(#[Value] $user, string $id, #[Entity] Date $date) {
-    $this->repository->modify($id, ['$set' => ['published' => $date]]);
+
+    // If this entry does not contain any images, use the first image of the latest
+    // child element as the preview image. This will update the preview image every
+    // time new content is added.
+    $entry= $this->repository->entry($id, published: false);
+    if (empty($entry['images'])) {
+      $first= $this->repository->children($id)->first();
+      $preview= empty($first['images']) ? null : ['slug' => $first['slug'], ...$first['images'][0]];
+    } else {
+      $preview= ['slug' => $id, ...$entry['images'][0]];
+    }
+    $this->repository->modify($id, ['$set' => ['published' => $date, 'preview' => $preview]]);
 
     return ['published' => $date];
   }

--- a/src/main/php/de/thekid/dialog/web/Journey.php
+++ b/src/main/php/de/thekid/dialog/web/Journey.php
@@ -14,7 +14,7 @@ class Journey {
     $journey= $this->repository->entry($id) ?? throw new Error(404, 'Not found: '.$id);
     return [
       'journey'   => $journey,
-      'itinerary' => $this->repository->children($id),
+      'itinerary' => $this->repository->children($id)->all(),
       'scroll'    => fn($node, $context, $options) => substr($options[0], strlen($id) + 1),
       'text'      => fn($node, $context, $options) => strip_tags($options[0]),
     ];


### PR DESCRIPTION
## In a nutshell

For a journey, the top images (of which the first is used for previewing) will most probably not be set until after the journey has finished. Instead of leaving the preview image empty, we choose the first image from the latest child content. This will update the preview image every time new content is added.

## Migration script

All entries are now expected to have a `preview` element. It can be created by either re-importing everything or by running this script:

```php
use com\mongodb\MongoConnection;
use util\cmd\Console;

$conn= new MongoConnection($argv[0]);
$collection= $conn->database($argv[1])->collection('entries');
foreach ($collection->find() as $entry) {
  Console::writeLine('> ', $entry['title']);

  // Create preview field and set it to the first image
  $preview= empty($entry['images']) ? null : ['slug' => $entry['slug'], ...$entry['images'][0]];
  $collection->update($entry->id(), ['$set' => ['preview' => $preview]]);
}
```

*Note this script only sets the preview field, it does not query the children as the import API does. This is because I haven't encountered this situation before 😉*