### PR TITLE
Migrate to new testing library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
         echo "vendor/autoload.php" > composer.pth
 
     - name: Run test suite
-      run: sh xp-run xp.unittest.TestRunner src/test/php
+      run: sh xp-run xp.test.Runner src/test/php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -46,4 +46,4 @@ jobs:
       run: sh xp-run xp.frontend.BundleRunner -m src/main/webapp/assets/manifest.json src/main/webapp/assets
 
     - name: Run tests
-      run: sh xp-run xp.unittest.TestRunner src/it/php -a mongodb://localhost:${{ job.services.mongodb.ports[27017] }}
+      run: sh xp-run xp.test.Runner src/it/php -- mongodb://localhost:${{ job.services.mongodb.ports[27017] }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -46,4 +46,4 @@ jobs:
       run: sh xp-run xp.frontend.BundleRunner -m src/main/webapp/assets/manifest.json src/main/webapp/assets
 
     - name: Run tests
-      run: sh xp-run xp.test.Runner src/it/php -- mongodb://localhost:${{ job.services.mongodb.ports[27017] }}
+      run: sh xp-run xp.test.Runner src/it/php --dsn=mongodb://localhost:${{ job.services.mongodb.ports[27017] }}

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
 
   "require-dev": {
-    "xp-framework/test": "dev-main"
+    "xp-framework/test": "^1.0"
   },
 
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
 
   "require-dev": {
-    "xp-framework/unittest": "^11.0"
+    "xp-framework/test": "dev-main"
   },
 
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
 
   "require-dev": {
-    "xp-framework/test": "dev-feature/command-line-args"
+    "xp-framework/test": "dev-main"
   },
 
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
 
   "require-dev": {
-    "xp-framework/test": "dev-main"
+    "xp-framework/test": "dev-feature/command-line-args"
   },
 
   "scripts": {

--- a/src/it/php/de/thekid/dialog/unittest/ServeTest.php
+++ b/src/it/php/de/thekid/dialog/unittest/ServeTest.php
@@ -9,7 +9,7 @@ use web\Environment;
 use web\io\{TestInput, TestOutput};
 use web\{Request, Response};
 
-#[Args]
+#[Args('dsn')]
 class ServeTest {
   private $conn, $routing;
 

--- a/src/it/php/de/thekid/dialog/unittest/ServeTest.php
+++ b/src/it/php/de/thekid/dialog/unittest/ServeTest.php
@@ -1,9 +1,9 @@
 <?php namespace de\thekid\dialog\unittest;
 
-use com\mongodb\{MongoConnection, Document};
+use com\mongodb\{Document, MongoConnection};
 use de\thekid\dialog\{App, Storage};
 use io\Path;
-use unittest\{Assert};
+use test\Assert;
 use util\Date;
 use web\Environment;
 use web\io\{TestInput, TestOutput};

--- a/src/it/php/de/thekid/dialog/unittest/ServeTest.php
+++ b/src/it/php/de/thekid/dialog/unittest/ServeTest.php
@@ -3,12 +3,13 @@
 use com\mongodb\{Document, MongoConnection};
 use de\thekid\dialog\{App, Storage};
 use io\Path;
-use test\Assert;
+use test\{Args, Assert, Before, Test};
 use util\Date;
 use web\Environment;
 use web\io\{TestInput, TestOutput};
 use web\{Request, Response};
 
+#[Args]
 class ServeTest {
   private $conn, $routing;
 

--- a/src/test/php/de/thekid/dialog/unittest/DescriptionsTest.php
+++ b/src/test/php/de/thekid/dialog/unittest/DescriptionsTest.php
@@ -16,7 +16,7 @@ class DescriptionsTest {
     new Descriptions();
   }
 
-  #[Test, Expect(FormatException::class), Values(list: ['', 'Content'])]
+  #[Test, Expect(FormatException::class), Values(['', 'Content'])]
   public function parse_input_without_yfm($input) {
     $this->parse($input);
   }

--- a/src/test/php/de/thekid/dialog/unittest/DescriptionsTest.php
+++ b/src/test/php/de/thekid/dialog/unittest/DescriptionsTest.php
@@ -3,7 +3,7 @@
 use de\thekid\dialog\import\{Description, Descriptions};
 use io\streams\MemoryInputStream;
 use lang\FormatException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 class DescriptionsTest {
 
@@ -16,7 +16,7 @@ class DescriptionsTest {
     new Descriptions();
   }
 
-  #[Test, Expect(FormatException::class), Values(['', 'Content'])]
+  #[Test, Expect(FormatException::class), Values(list: ['', 'Content'])]
   public function parse_input_without_yfm($input) {
     $this->parse($input);
   }

--- a/src/test/php/de/thekid/dialog/unittest/FilesTest.php
+++ b/src/test/php/de/thekid/dialog/unittest/FilesTest.php
@@ -1,7 +1,7 @@
 <?php namespace de\thekid\dialog\unittest;
 
 use de\thekid\dialog\processing\{Files, Images};
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 class FilesTest {
 

--- a/src/test/php/de/thekid/dialog/unittest/HelpersTest.php
+++ b/src/test/php/de/thekid/dialog/unittest/HelpersTest.php
@@ -1,7 +1,7 @@
 <?php namespace de\thekid\dialog\unittest;
 
 use de\thekid\dialog\Helpers;
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class HelpersTest {
   private $helpers= [...new Helpers()->helpers()];

--- a/src/test/php/de/thekid/dialog/unittest/PaginationTest.php
+++ b/src/test/php/de/thekid/dialog/unittest/PaginationTest.php
@@ -2,7 +2,7 @@
 
 use de\thekid\dialog\Pagination;
 use lang\IllegalArgumentException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 class PaginationTest {
   private const PAGED = 5;

--- a/src/test/php/de/thekid/dialog/unittest/PreferencesTest.php
+++ b/src/test/php/de/thekid/dialog/unittest/PreferencesTest.php
@@ -63,7 +63,7 @@ class PreferencesTest {
     Assert::equals('set', $fixture->{$op}('mongo', 'uri'));
   }
 
-  #[Test, Expect(class: NoSuchElementException::class, withMessage: '/Missing.+mongo::uri/')]
+  #[Test, Expect(class: NoSuchElementException::class, message: '/Missing.+mongo::uri/')]
   public function get_raises_exception_if_not_found() {
     $fixture= new Preferences($this->environment(null)->export([]), 'config');
 

--- a/src/test/php/de/thekid/dialog/unittest/PreferencesTest.php
+++ b/src/test/php/de/thekid/dialog/unittest/PreferencesTest.php
@@ -1,7 +1,7 @@
 <?php namespace de\thekid\dialog\unittest;
 
 use de\thekid\dialog\Preferences;
-use unittest\{Assert, Before, Expect, Test, Values};
+use test\{Assert, Before, Expect, Test, Values};
 use util\NoSuchElementException;
 use util\{Properties, RegisteredPropertySource};
 use web\Environment;

--- a/src/test/php/de/thekid/dialog/unittest/SigningTest.php
+++ b/src/test/php/de/thekid/dialog/unittest/SigningTest.php
@@ -2,7 +2,7 @@
 
 use de\thekid\dialog\Signing;
 use text\hash\Hashing;
-use unittest\{Assert, Before, Test, Values};
+use test\{Assert, Before, Test, Values};
 use util\Secret;
 
 class SigningTest {

--- a/src/test/php/de/thekid/dialog/unittest/StorageTest.php
+++ b/src/test/php/de/thekid/dialog/unittest/StorageTest.php
@@ -2,7 +2,7 @@
 
 use de\thekid\dialog\Storage;
 use io\Folder;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class StorageTest {
   private $base= new Folder('.');


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/344 and https://github.com/xp-framework/test. Mostly migrated automatically, needed a small change for the integration tests, see https://github.com/xp-framework/test/issues/2 (*add `#[Args]`*)

## Timing

Before
```
Tests:       70 passed
Memory used: 4653.14 kB (4706.05 kB peak)
Time taken:  0.087 seconds
```

After
```
Test cases:  70 succeeded
Memory used: 4538.74 kB (4596.54 kB peak)
Time taken:  0.086 seconds (0.458 seconds overall)
```