### PR TITLE
Instead of manually aggregating children, use MongoDB 5.2+ features

### DIFF
--- a/src/main/php/de/thekid/dialog/api/Entries.php
+++ b/src/main/php/de/thekid/dialog/api/Entries.php
@@ -27,6 +27,7 @@ class Entries {
       'locations'   => $attributes['locations'],
       'content'     => $attributes['content'],
       'is'          => $attributes['is'],
+      'images'      => [],
       '_searchable' => [
         'boost'   => isset($attributes['is']['journey']) ? 2.0 : 1.0,
         'suggest' => trim($suggest),
@@ -59,7 +60,7 @@ class Entries {
         }
 
         // Fetch entry again, it might have changed in the meantime!
-        $images= $this->repository->entry($id, published: false)['images'] ?? [];
+        $images= $this->repository->entry($id, published: false)['images'];
 
         // Modify existing image, appending it if not existant
         $is= preg_match('/\.(mp4|mov|webm)$/i', $name) ? 'video' : 'image';


### PR DESCRIPTION
See #52. Query performance is no problem, LightHouse score (see #18) stays at a stable 100:

<img width="411" alt="image" src="https://user-images.githubusercontent.com/696742/235366679-dab02998-a07d-472d-a89d-f9d80c87dc07.png">
