### PR TITLE
Use semantic HTML search element

### DIFF
--- a/src/main/handlebars/home.handlebars
+++ b/src/main/handlebars/home.handlebars
@@ -23,7 +23,9 @@
       </article>
     {{/with}}
 
-    {{> partials/search}}
+    <search>
+      {{> partials/search}}
+    </search>
 
     <!-- Newest content -->
     <h2 class="news">Neueste Inhalte</h2>

--- a/src/main/handlebars/search.handlebars
+++ b/src/main/handlebars/search.handlebars
@@ -11,47 +11,49 @@ parent: feed
   {{/inline}}
   {{#*inline "main"}}
     <h1 class="title">Dialog - Suche</h1>
-    {{> partials/search owns='results'}}
+    <search>
+      {{> partials/search owns='results'}}
 
-    <div id="results">
-      {{#with results.elements}}
-        <div class="summary">Seite {{results.page}} von {{meta.count.lowerBound.number}} Ergebnissen in {{time}} Sekunden</div>
-        {{#each .}}
-          <section>
-            <h2><a href="{{route this}}">{{#if is.journey}}Reise: {{/if}}{{title}}</a></h2>
+      <div id="results">
+        {{#with results.elements}}
+          <div class="summary">Seite {{results.page}} von {{meta.count.lowerBound.number}} Ergebnissen in {{time}} Sekunden</div>
+          {{#each .}}
+            <section>
+              <h2><a href="{{route this}}">{{#if is.journey}}Reise: {{/if}}{{title}}</a></h2>
 
-            <div class="meta">
-              {{date ./date format="d.m.Y"}} @
-              <ul class="locations" role="list">
-                {{#each locations}}
-                  <li><a title="@{{lat}},{{lon}}" href="{{link}}">{{name}}</a></li>
-                {{/each}}
-              </ul>
-            </div>
+              <div class="meta">
+                {{date ./date format="d.m.Y"}} @
+                <ul class="locations" role="list">
+                  {{#each locations}}
+                    <li><a title="@{{lat}},{{lon}}" href="{{link}}">{{name}}</a></li>
+                  {{/each}}
+                </ul>
+              </div>
 
-            {{#if is.journey}}
-              {{> partials/images in=. first=@first style='overview'}}
-            {{/if}}
+              {{#if is.journey}}
+                {{> partials/images in=. first=@first style='overview'}}
+              {{/if}}
 
-            <div class="excerpt">
-              {{&excerpt . '_searchable.content' 'content'}}
-            </div>
+              <div class="excerpt">
+                {{&excerpt . '_searchable.content' 'content'}}
+              </div>
+            </section>
+          {{/each}}
+
+          <div class="pagination">
+            <a class="previous" href={{#if results.previous}}"/search?q={{encode request.params.q}}&amp;page={{results.previous}}"{{else}}"#" aria-disabled="true"{{/if}}>Vorherige</a>
+            <span class="page">Seite {{results.page}}</span>
+            <a class="next" href={{#if results.next}}"/search?q={{encode request.params.q}}&amp;page={{results.next}}"{{else}}"#" aria-disabled="true"{{/if}}>Nächste</a>
+          </div>
+
+        {{else}}
+          <section class="empty">
+            <h2>Keine Ergebnisse</h2>
+            <p>Suche nach etwas anderem...</p>
           </section>
-        {{/each}}
-
-        <div class="pagination">
-          <a class="previous" href={{#if results.previous}}"/search?q={{encode request.params.q}}&amp;page={{results.previous}}"{{else}}"#" aria-disabled="true"{{/if}}>Vorherige</a>
-          <span class="page">Seite {{results.page}}</span>
-          <a class="next" href={{#if results.next}}"/search?q={{encode request.params.q}}&amp;page={{results.next}}"{{else}}"#" aria-disabled="true"{{/if}}>Nächste</a>
-        </div>
-
-      {{else}}
-        <section class="empty">
-          <h2>Keine Ergebnisse</h2>
-          <p>Suche nach etwas anderem...</p>
-        </section>
-      {{/with}}
-    </div>
+        {{/with}}
+      </div>
+    </search>
   {{/inline}}
   {{#*inline "scripts"}}
     <script type="module">


### PR DESCRIPTION
This pull request wraps the search bar on the home page as well as the search page inside the semantic `<search>` element. Quoting MDN:

> The `<search>` element semantically identifies the purpose of the element's contents as having search or filtering capabilities

This improves accessibility in browsers supporting this tag.

![Element inspector screenshot](https://github.com/thekid/dialog/assets/696742/cbea9b05-3e52-48b9-9b22-afc9a5cc7c3c)

## See also

* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search
* https://caniuse.com/mdn-html_elements_search
* https://survey.devographics.com/de-DE/survey/state-of-html/2023
* https://stackoverflow.com/questions/37151908/what-happens-to-old-browsers-if-i-use-the-new-html5-tags