### PR TITLE
Balance layout for odd number of preview images

### DIFF
--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -522,6 +522,10 @@
       aspect-ratio: auto;
     }
 
+    .images:where(.size-3, .size-5, .size-7) .image:first-child {
+      grid-column: 1 / 3;
+    }
+
     .image img, .image video {
       aspect-ratio: 15 / 10;
       object-fit: cover;
@@ -663,6 +667,10 @@
     @media (max-width: 767px) {
       .images {
         grid-template-columns: 1fr;
+      }
+
+      .images .image:first-child {
+        grid-column: 1;
       }
 
       .images.overview {

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -514,15 +514,15 @@
       grid-template-columns: 1fr;
     }
 
-    .images.size-1 {
+    .images.is-single {
       grid-template-columns: 1fr;
     }
 
-    .images.size-1 video {
+    .images.is-single video {
       aspect-ratio: auto;
     }
 
-    .images:where(.size-3, .size-5, .size-7) .image:first-child {
+    .images:where(.is-odd) .image:first-child {
       grid-column: 1 / 3;
     }
 

--- a/src/main/handlebars/partials/images.handlebars
+++ b/src/main/handlebars/partials/images.handlebars
@@ -1,4 +1,4 @@
-<div class="images {{style}} size-{{size in.images}}">
+<div class="images {{style}} is-{{size-class (size in.images)}}">
   {{#each in.images}}
     <div class="image">
       {{#if is.video}}

--- a/src/main/php/de/thekid/dialog/Helpers.php
+++ b/src/main/php/de/thekid/dialog/Helpers.php
@@ -32,6 +32,15 @@ class Helpers extends Extension {
       if ($time > $until) return 'passed';
       return 'current';
     };
+    yield 'size-class' => function($node, $context, $options) {
+      $s= (int)$options[0];
+      return match {
+        0 === $s => 'empty',
+        1 === $s => 'single',
+        1 === $s % 2 => 'odd',
+        default => 'even',
+      };
+    };
     yield 'route' => function($node, $context, $options) {
       $entry= $options[0];
       if (isset($entry['is']['journey'])) {


### PR DESCRIPTION
...preventing large empty areas.

## Before

![Screenshot with 3 images](https://github.com/thekid/dialog/assets/696742/3bc5da93-2981-40ac-bb26-1e80c4550621)

## After

![Screenshot with 3 images](https://github.com/thekid/dialog/assets/696742/09bbb940-03c6-45f3-8003-ccccfc5370df)
