### PR TITLE
Refactor to make use of asymmetric visibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "bsd",
 
   "require": {
-    "xp-framework/compiler": "^9.0",
+    "xp-framework/compiler": "^9.3",
     "xp-framework/imaging": "^11.0",
     "xp-framework/command": "^12.0",
     "xp-framework/networking": "^10.4",

--- a/src/main/php/de/thekid/dialog/Pagination.php
+++ b/src/main/php/de/thekid/dialog/Pagination.php
@@ -6,7 +6,7 @@ use lang\IllegalArgumentException;
 class Pagination {
 
   /** @throws lang.IllegalArgumentException */
-  public function __construct(public readonly int $paged) {
+  public function __construct(public private(set) int $paged) {
     if ($paged < 1) {
       throw new IllegalArgumentException('Paged must be greater than 0');
     }

--- a/src/main/php/de/thekid/dialog/SearchResult.php
+++ b/src/main/php/de/thekid/dialog/SearchResult.php
@@ -7,7 +7,7 @@ class SearchResult {
   public static $EMPTY= new self(new Document(), []);
 
   public function __construct(
-    public readonly Document $meta,
-    public readonly iterable $documents,
+    public private(set) Document $meta,
+    public private(set) iterable $documents,
   ) { }
 }

--- a/src/main/php/de/thekid/dialog/import/Description.php
+++ b/src/main/php/de/thekid/dialog/import/Description.php
@@ -1,8 +1,8 @@
 <?php namespace de\thekid\dialog\import;
 
-readonly class Description {
+class Description {
   public function __construct(
-    public array<string, mixed> $meta,
-    public string $content
+    public private(set) array<string, mixed> $meta,
+    public private(set) string $content
   ) { }
 }


### PR DESCRIPTION
This pull request changes all instances of `readonly` for [asymmetric visibility](https://wiki.php.net/rfc/asymmetric-visibility-v2), namely `public private(set)`. Though *readonly* reads nicely, the reasoning is that **if *readonly* had never been added to PHP, I could achieve anything I want with asymmetric visibility**; and I'm happy to have one way of doing things.

The only benefit *readonly* provides is that properties cannot be written to it after having been initialized (typically inside the constructor) - dubbed *init-once* properties. As the only place I would do that would be *inside* the given class anyway this feels like needlessly restricting myself.

By using [XP Compiler](https://github.com/xp-framework/compiler), I can still support all PHP versions >= 7.4  even though asymmetric visibility is PHP 8.4+ feature.

/cc @mikey179

* * * 

⚠️ *Tests are failing because the Ubuntu PHP 8.4 build on GitHub Actions is not up-to-date.*