### PR TITLE
Extract OpenLayers mapping JS & CSS into separate bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   },
   "bundles": {
     "vendor": {
-      "ol": "ol.css | dist/ol.js",
       "fonts://display=swap": "Barlow",
       ".": "src/main/js/*.js"
+    },
+    "mapping": {
+      "ol": "ol.css | dist/ol.js"
     }
   }
 }

--- a/src/main/handlebars/content.handlebars
+++ b/src/main/handlebars/content.handlebars
@@ -4,6 +4,7 @@ parent: feed
 {{#> layout}}
   {{#*inline "title"}}{{item.title}}{{/inline}}
   {{#*inline "meta"}}
+    <link rel="stylesheet" type="text/css" href="/assets/{{asset 'mapping.css'}}">
     <meta property="og:url" content="{{request.uri}}">
     <meta property="og:type" content="article">
     <meta property="og:title" content="{{item.title}} - Dialog">
@@ -38,6 +39,7 @@ parent: feed
     </section>
   {{/inline}}
   {{#*inline "scripts"}}
+    <script src="/assets/{{asset 'mapping.js'}}" defer></script>
     <script type="module">
       {{&use 'mapping'}}
       const mapping = new Mapping('/static/marker.png');

--- a/src/main/handlebars/journey.handlebars
+++ b/src/main/handlebars/journey.handlebars
@@ -4,6 +4,7 @@ parent: feed
 {{#> layout}}
   {{#*inline "title"}}{{journey.title}}{{/inline}}
   {{#*inline "meta"}}
+    <link rel="stylesheet" type="text/css" href="/assets/{{asset 'mapping.css'}}">
     <meta property="og:url" content="{{request.uri}}">
     <meta property="og:type" content="article">
     <meta property="og:title" content="{{journey.title}} - Dialog">
@@ -78,6 +79,7 @@ parent: feed
     {{/with}}
   {{/inline}}
   {{#*inline "scripts"}}
+    <script src="/assets/{{asset 'mapping.js'}}" defer></script>
     <script type="module">
       {{&use 'mapping'}}
       const mapping = new Mapping('/static/marker.png');

--- a/src/main/handlebars/journeys.handlebars
+++ b/src/main/handlebars/journeys.handlebars
@@ -1,6 +1,7 @@
 {{#> layout}}
   {{#*inline "title"}}Reisen{{/inline}}
   {{#*inline "meta"}}
+    <link rel="stylesheet" type="text/css" href="/assets/{{asset 'mapping.css'}}">
     <meta property="og:url" content="{{request.uri}}">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Reisen - Dialog">
@@ -28,6 +29,7 @@
     </div>
   {{/inline}}
   {{#*inline "scripts"}}
+    <script src="/assets/{{asset 'mapping.js'}}" defer></script>
     <script type="module">
       {{&use 'mapping'}}
       const mapping = new Mapping('/static/marker.png');


### PR DESCRIPTION
Reduces the amount of JS to be loaded for the home page by ~816 kilobytes (223 kb gzipped, 181.44 brotli-compressed):

* vendor.65508de.css: 0.16 kB
* vendor.5051e0f.js: 7.39 kB
* mapping.6c2eb06.css: 6.19 kB
* mapping.e89e002.js: 815.88 kB