### PR TITLE
Add Atom feed

### DIFF
--- a/src/main/handlebars/atom.handlebars
+++ b/src/main/handlebars/atom.handlebars
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Feed - Dialog - Timm Friebe</title>
+  <link href="{{request.uri.base}}/feed/atom" rel="self"/>
+  <updated>{{date items.0.date format="c"}}</updated>
+  <author><name>Timm Friebe</name></author>
+  <id>urn:uuid:abf3ae67-8d43-497f-bd40-f7fb793eed4f</id>
+
+  {{#each items}}
+    <entry>
+      <title>{{title}}</title>
+      <link href="{{request.uri.base}}/{{route this}}"/>
+      <id>urn:oid:{{_id}}</id>
+      <updated>{{date ./date format="c"}}</updated>
+      <summary type="html">{{content}}</summary>
+    </entry>
+  {{/each}}
+</feed>

--- a/src/main/handlebars/atom.handlebars
+++ b/src/main/handlebars/atom.handlebars
@@ -12,7 +12,10 @@
       <link href="{{request.uri.base}}/{{route this}}"/>
       <id>urn:oid:{{_id}}</id>
       <updated>{{date ./date format="c"}}</updated>
-      <summary type="html">{{content}}</summary>
+      <summary type="html">
+        {{#with images.0}}&lt;img src="/image/{{slug}}/preview-{{name}}.jpg"&gt;{{/with}}&lt;br&gt;
+        {{content}}
+      </summary>
     </entry>
   {{/each}}
 </feed>

--- a/src/main/handlebars/atom.handlebars
+++ b/src/main/handlebars/atom.handlebars
@@ -12,10 +12,11 @@
       <link href="{{request.uri.base}}/{{route this}}"/>
       <id>urn:oid:{{_id}}</id>
       <updated>{{date ./date format="c"}}</updated>
-      <summary type="html">
+      <summary type="text">{{#each locations}}{{.}}{{#unless @last}}, {{/unless}}{{/each}}</summary>
+      <content type="html">
         {{#with images.0}}&lt;img src="/image/{{slug}}/preview-{{name}}.jpg"&gt;{{/with}}&lt;br&gt;
         {{content}}
-      </summary>
+      </content>
     </entry>
   {{/each}}
 </feed>

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -9,6 +9,7 @@
   {{> meta}}
   <link rel="stylesheet" type="text/css" href="/assets/{{asset 'vendor.css'}}">
   <link rel="icon" type="image/svg+xml" href="/static/icon.svg">
+  <link rel="alternate" type="application/atom+xml" title="Atom Feed" href="/feed/atom"/>
   <style type="text/css">
     /* CSS reset, see https://piccalil.li/blog/a-modern-css-reset/ */
     *, *::before, *::after {

--- a/src/main/php/de/thekid/dialog/web/Feed.php
+++ b/src/main/php/de/thekid/dialog/web/Feed.php
@@ -1,7 +1,7 @@
 <?php namespace de\thekid\dialog\web;
 
 use de\thekid\dialog\{Repository, Pagination};
-use web\frontend\{Handler, Get, Param};
+use web\frontend\{Handler, Get, Param, View};
 
 #[Handler('/feed')]
 class Feed {
@@ -12,5 +12,13 @@ class Feed {
   #[Get]
   public function listing(#[Param] $page= 1) {
     return $this->repository->entries($this->pagination, (int)$page);
+  }
+
+  #[Get('/atom')]
+  public function atom() {
+    return View::named('atom')
+      ->header('Content-Type', 'application/atom+xml; charset=utf-8')
+      ->with(['items' => $this->repository->newest(20)])
+    ;
   }
 }


### PR DESCRIPTION
Implements #63 using an Atom feed at `/feed/atom`, showing the 20 newest entries, each with one preview image. 

### Examples

*Feedly:*

![Feedly](https://github.com/user-attachments/assets/2b2a8423-8148-407b-b16e-dd17a4e7ca37)

*Outlook:*

![Outlook](https://github.com/user-attachments/assets/c89ee416-1f06-498f-a5d6-edae898a3c90)

### See also

* https://stackoverflow.com/questions/3489578/which-is-most-used-rss-or-atom-and-which-one-is-better-to-build-from and https://nelsonslog.wordpress.com/2022/07/22/writing-an-atom-feed-in-2022/ for my choice on Atom vs. RSS 
* https://stackoverflow.com/questions/29798315/adding-images-or-thumbnails-to-atom-1-0-entries for how to embed images in feeds.
* https://www.ietf.org/rfc/rfc4287.txt - the Atom web standard