### PR TITLE
Switch journeys to display entries oldest - newest

### DIFF
--- a/src/main/handlebars/content.handlebars
+++ b/src/main/handlebars/content.handlebars
@@ -51,9 +51,10 @@ parent: feed
       mapping.project(document.querySelector('#map'));
 
       // Update statistics
-      window.setTimeout(() => {
-        fetch('/api/statistics/{{item.slug}}', {method: 'POST', body: '{{sign item.slug}}'});
-      }, Math.min({{size item.images}} * 1500, 5000));
+      {{&use 'statistics'}}
+      const statistics = new Statistics();
+      statistics.add('{{item.slug}}', '{{sign item.slug}}', Math.min({{size item.images}} * 1500, 5000));
+      statistics.schedule('{{item.slug}}');
     </script>
   {{/inline}}
 {{/layout}}

--- a/src/main/handlebars/feed.handlebars
+++ b/src/main/handlebars/feed.handlebars
@@ -22,7 +22,12 @@
     {{#with elements}}
       {{#each .}}
         <section>
-          <h2 class="{{range-rel is.from is.until}} date"><a href="{{route this}}">{{title}}</a></h2>
+          <h2>
+            {{#with parent}}
+              <span class="journey"><a href="{{route this}}">{{title}}</a> » </span>
+            {{/with}}
+            <a href="{{route this}}">{{title}}</a>
+          </h2>
 
           <div class="meta">
             {{date ./date format="d.m.Y"}} @

--- a/src/main/handlebars/feed.handlebars
+++ b/src/main/handlebars/feed.handlebars
@@ -24,7 +24,9 @@
         <section>
           <h2>
             {{#with parent}}
-              <span class="journey"><a href="{{route this}}">{{title}}</a> » </span>
+              <span class="journey" title="Reise, {{range is.from is.until format="M Y"}}">
+                <a href="{{route this}}">{{title}}</a>
+              </span>
             {{/with}}
             <a href="{{route this}}">{{title}}</a>
           </h2>

--- a/src/main/handlebars/feed.handlebars
+++ b/src/main/handlebars/feed.handlebars
@@ -39,11 +39,7 @@
             {{count views '' '(Eine Ansicht)' '(# Ansichten)'}}
           </div>
 
-          {{#if images}}
-            {{> partials/images in=. first=@first}}
-          {{else}}
-            {{> partials/cards in=children}}
-          {{/if}}
+          {{> partials/images in=. first=@first}}
 
           <div class="content">
             {{& content}}

--- a/src/main/handlebars/journey.handlebars
+++ b/src/main/handlebars/journey.handlebars
@@ -63,6 +63,7 @@ parent: feed
                 <li><a href="{{link}}">{{name}}</a></li>
               {{/each}}
             </ul>
+            {{count views '' '(Eine Ansicht)' '(# Ansichten)'}}
           </div>
           {{> partials/images in=.}}
 
@@ -103,9 +104,9 @@ parent: feed
         (entries) => {
           for (const entry of entries) {
             if (entry.isIntersecting) {
-              statistics.schedule(entry.target.id);
+              statistics.schedule('{{journey.slug}}/' + entry.target.id);
             } else {
-              statistics.withdraw(entry.target.id);
+              statistics.withdraw('{{journey.slug}}/' + entry.target.id);
             }
           }
         },
@@ -113,7 +114,7 @@ parent: feed
       );
       {{#each itinerary}}
         observer.observe(document.querySelector('#{{scroll slug}}'));
-        statistics.add('{{scroll slug}}', '{{sign slug}}', Math.min({{size images}} * 1500, 5000));
+        statistics.add('{{slug}}', '{{sign slug}}', Math.min({{size images}} * 1500, 5000));
       {{/each}}
     </script>
   {{/inline}}

--- a/src/main/handlebars/journey.handlebars
+++ b/src/main/handlebars/journey.handlebars
@@ -14,7 +14,7 @@ parent: feed
     {{/with}}
   {{/inline}}
   {{#*inline "main"}}
-    <h1 class="title">Dialog - {{journey.title}}</h1>
+    <h1 class="{{range-rel journey.is.from journey.is.until}} title">Dialog - {{journey.title}}</h1>
 
     <!-- The journey itself -->
     <section id="summary">

--- a/src/main/handlebars/journey.handlebars
+++ b/src/main/handlebars/journey.handlebars
@@ -92,10 +92,29 @@ parent: feed
 
       mapping.project(document.querySelector('#map'));
 
-      // Update statistics
-      window.setTimeout(() => {
-        fetch('/api/statistics/{{journey.slug}}', {method: 'POST', body: '{{sign journey.slug}}'});
-      }, 10000);
+      // Update statistics for journey after a little while. To determine which entries the
+      // user has spent time viewing, use intersection observer
+      {{&use 'statistics'}}
+      const statistics = new Statistics();
+      statistics.add('{{journey.slug}}', '{{sign journey.slug}}', 10000);
+      statistics.schedule('{{journey.slug}}');
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting) {
+              statistics.schedule(entry.target.id);
+            } else {
+              statistics.withdraw(entry.target.id);
+            }
+          }
+        },
+        { threshold: 0.2 }
+      );
+      {{#each itinerary}}
+        observer.observe(document.querySelector('#{{scroll slug}}'));
+        statistics.add('{{scroll slug}}', '{{sign slug}}', Math.min({{size images}} * 1500, 5000));
+      {{/each}}
     </script>
   {{/inline}}
 {{/layout}}

--- a/src/main/handlebars/journeys.handlebars
+++ b/src/main/handlebars/journeys.handlebars
@@ -20,7 +20,7 @@
       {{#each journeys}}
         <div class="card">
           <div class="{{range-rel is.from is.until}} context">{{range is.from is.until format="M Y"}}</div>
-          <a title="{{title}}" href="/journey/{{slug}}">
+          <a title="{{title}}" href="{{route this}}">
             {{#with preview}}<img alt="{{title}}, {{date meta.dateTime format='d.m.Y H:i'}}" {{#unless (top 3 @index)}}loading="lazy"{{/unless}} src="/image/{{slug}}/thumb-{{name}}.webp">{{else}}<div class="without-preview"></div>{{/with}}
             <h3>{{title}}</h3>
           </a>

--- a/src/main/handlebars/journeys.handlebars
+++ b/src/main/handlebars/journeys.handlebars
@@ -19,7 +19,7 @@
     <div class="cards">
       {{#each journeys}}
         <div class="card">
-          <div class="{{range-rel is.from is.until}} date">{{range is.from is.until format="M Y"}}</div>
+          <div class="{{range-rel is.from is.until}} context">{{range is.from is.until format="M Y"}}</div>
           <a title="{{title}}" href="/journey/{{slug}}">
             {{#with preview}}<img alt="{{title}}, {{date meta.dateTime format='d.m.Y H:i'}}" {{#unless (top 3 @index)}}loading="lazy"{{/unless}} src="/image/{{slug}}/thumb-{{name}}.webp">{{else}}<div class="without-preview"></div>{{/with}}
             <h3>{{title}}</h3>

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -395,6 +395,15 @@
       }
     }
 
+    h1.current::before {
+      content: 'LIVE';
+      background-color: orange;
+      margin-right: .5rem;
+      padding: .125rem .4rem;
+      border-radius: .25rem;
+      font-size: 1.15rem;
+    }
+
     section {
       padding-top: 1rem;
       margin-bottom: 3rem;
@@ -412,15 +421,6 @@
 
       h2 a {
         color: var(--text-color);
-      }
-
-      h2.current::before {
-        content: 'LIVE';
-        background-color: orange;
-        margin-right: .5rem;
-        padding: .125rem .4rem;
-        border-radius: .25rem;
-        font-size: 1rem;
       }
 
       h2 .top {

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -364,10 +364,14 @@
         position: absolute;
         top: .75rem;
         left: .75rem;
-        background-color: black;
+        background-color: var(--main-color);
         border-radius: .25rem;
-        color: white;
+        color: var(--text-color);
         padding: .125rem .4rem;
+
+        .journey a {
+          color: var(--text-color);
+        }
 
         .journey::before {
           content: '—';
@@ -376,6 +380,7 @@
 
         &.current {
           background-color: orange;
+          color: white;
         }
 
         &.current::before {

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -422,6 +422,10 @@
       h2 {
         font-size: 1.5rem;
         font-weight: 700;
+
+        .journey::after {
+          content: '»';
+        }
       }
 
       h2.scroll {

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -360,7 +360,7 @@
         box-shadow: .5rem .5rem 1rem rgb(0 0 0 / .2);
       }
 
-      .date {
+      .context {
         position: absolute;
         top: .75rem;
         left: .75rem;
@@ -368,17 +368,22 @@
         border-radius: .25rem;
         color: white;
         padding: .125rem .4rem;
-      }
 
-      .current.date {
-        background-color: orange;
-      }
+        .journey::before {
+          content: '—';
+          margin-right: .25rem;
+        }
 
-      .current.date::before {
-        content: 'LIVE';
-        margin-right: .25rem;
-        padding-right: .25rem;
-        border-right: 1px solid white;
+        &.current {
+          background-color: orange;
+        }
+
+        &.current::before {
+          content: 'LIVE';
+          margin-right: .25rem;
+          padding-right: .25rem;
+          border-right: 1px solid white;
+        }
       }
 
       h3 {

--- a/src/main/handlebars/partials/cards.handlebars
+++ b/src/main/handlebars/partials/cards.handlebars
@@ -10,9 +10,14 @@
     {{else}}
       <div class="card">
         {{#if is.content}}
-          <div class="date">{{date ./date format='d.m.Y'}}</div>
+          <div class="context">
+            <span class="date">{{date ./date format='d.m.Y'}}</span>
+            {{#with parent}}
+              <span class="journey"><a href="{{route this}}">{{title}}</a></span>
+            {{/with}}
+          </div>
         {{else if is.journey}}
-          <div class="{{range-rel is.from is.until}} date">{{range is.from is.until format="M Y"}}</div>
+          <div class="{{range-rel is.from is.until}} context">{{range is.from is.until format="M Y"}}</div>
         {{/if}}
         <a title="{{title}}" href="{{route this}}">
           {{#with preview}}<img alt="{{title}}, {{date meta.dateTime format='d.m.Y H:i'}}" src="/image/{{slug}}/thumb-{{name}}.webp">{{else}}<div class="without-preview"></div>{{/with}}

--- a/src/main/js/statistics.js
+++ b/src/main/js/statistics.js
@@ -1,0 +1,29 @@
+class Statistics {
+  #tasks = {};
+
+  /** Adds a statistics target with a given delay */
+  add(target, signature, delay) {
+    this.#tasks[target] = { signature, delay, timer : null, completed : false };
+  }
+
+  /** Schedules the given statistics target */
+  schedule(target) {
+    const task = this.#tasks[target];
+    if (task === undefined) throw new Error(`Undefined target ${target}`);
+
+    task.timer && clearTimeout(task.timer);
+    task.completed || (task.timer = setTimeout(
+      () => fetch('/api/statistics/' + target, { method: 'POST', body: task.signature }).then(() => task.completed = true),
+      task.delay
+    ));
+  }
+
+  /** Withdraws any scheduling for the given statistics target */
+  withdraw(target) {
+    const task = this.#tasks[target];
+    if (task === undefined) return;
+
+    clearTimeout(task.timer);
+    task.timer = null; 
+  }
+}

--- a/src/main/php/de/thekid/dialog/web/Feed.php
+++ b/src/main/php/de/thekid/dialog/web/Feed.php
@@ -5,7 +5,7 @@ use web\frontend\{Handler, Get, Param, View};
 
 #[Handler('/feed')]
 class Feed {
-  private $pagination= new Pagination(5);
+  private $pagination= new Pagination(8);
 
   public function __construct(private Repository $repository) { }
 

--- a/src/main/php/de/thekid/dialog/web/Home.php
+++ b/src/main/php/de/thekid/dialog/web/Home.php
@@ -12,7 +12,7 @@ class Home {
   public function index() {
     return View::named('home')->with([
       'cover'  => $this->repository->entry('@cover'),
-      'newest' => $this->repository->newest(6),
+      'newest' => $this->repository->newest(9),
     ]);
   }
 

--- a/src/main/php/de/thekid/dialog/web/Journey.php
+++ b/src/main/php/de/thekid/dialog/web/Journey.php
@@ -14,7 +14,7 @@ class Journey {
     $journey= $this->repository->entry($id) ?? throw new Error(404, 'Not found: '.$id);
     return [
       'journey'   => $journey,
-      'itinerary' => $this->repository->children($id)->all(),
+      'itinerary' => $this->repository->children($id, ['date' => 1])->all(),
       'scroll'    => fn($node, $context, $options) => substr($options[0], strlen($id) + 1),
       'text'      => fn($node, $context, $options) => strip_tags($options[0]),
     ];


### PR DESCRIPTION
This pull request changes the order of entries displayed inside journeys from the "blog style" (newest entries at the top) to the "story style" (newest entries at the bottom). This makes it easier to read through the journeys in retrospect. To make it easy to catch up with what's new, the news feed now displays journeys' children directly.

* [x] Include journey children in web and Atom feeds
* [x] Switch journey to "story style" view with oldest entries first
* [x] Show "LIVE" indicator on journey page
* [x] Show whether element is part of journey on front page

Inspired by https://findpenguins.com/