### PR TITLE
Add text before images

### DIFF
--- a/src/it/php/de/thekid/dialog/unittest/ServeTest.php
+++ b/src/it/php/de/thekid/dialog/unittest/ServeTest.php
@@ -44,19 +44,37 @@ class ServeTest {
   #[Test]
   public function serves_robots_txt() {
     $res= $this->serve('GET', '/robots.txt');
-    Assert::equals([200, 'text/plain; charset=utf-8'], [$res->status(), $res->headers()['Content-Type']]);
+    Assert::equals(
+      [200, 'text/plain; charset=utf-8'],
+      [$res->status(), $res->headers()['Content-Type']]
+    );
   }
 
   #[Test]
   public function serves_homepage() {
     $res= $this->serve('GET', '/');
-    Assert::equals([200, 'text/html; charset=utf-8'], [$res->status(), $res->headers()['Content-Type']]);
+    Assert::equals(
+      [200, 'text/html; charset=utf-8'], 
+      [$res->status(), $res->headers()['Content-Type']]
+    );
+  }
+
+  #[Test]
+  public function serves_atomfeed() {
+    $res= $this->serve('GET', '/feed/atom');
+    Assert::equals(
+      [200, 'application/atom+xml; charset=utf-8'],
+      [$res->status(), $res->headers()['Content-Type']]
+    );
   }
 
   #[Test]
   public function type_ahead_api_publicly_accessible() {
     $res= $this->serve('GET', '/api/suggestions?q=');
-    Assert::equals([200, 'application/json; charset=utf-8'], [$res->status(), $res->headers()['Content-Type']]);
+    Assert::equals(
+      [200, 'application/json; charset=utf-8'],
+      [$res->status(), $res->headers()['Content-Type']]
+    );
   }
 
   #[Test]

--- a/src/main/handlebars/content.handlebars
+++ b/src/main/handlebars/content.handlebars
@@ -31,9 +31,7 @@ parent: feed
         <div class="popup"></div>
       </div>
 
-      <div class="content">
-        {{& item.content}}
-      </div>
+      <div class="content">{{& item.content}}</div>
 
       {{> partials/images in=item style='all'}}
     </section>

--- a/src/main/handlebars/feed.handlebars
+++ b/src/main/handlebars/feed.handlebars
@@ -42,6 +42,8 @@
             {{> partials/weather in=.}}
           </div>
 
+          <div class="content">{{& content}}</div>
+
           {{! Content formed of a single video can be played back inline directly }}
           {{#if (all (equals 1 (size images)) images.0.is.video)}}
             <div class="images is-single">
@@ -71,10 +73,6 @@
               </div>
             </a>
           {{/if}}
-
-          <div class="content">
-            {{& content}}
-          </div>
         </section>
       {{/each}}
     {{else}}

--- a/src/main/handlebars/journey.handlebars
+++ b/src/main/handlebars/journey.handlebars
@@ -33,9 +33,7 @@ parent: feed
         <div class="popup"></div>
       </div>
 
-      <div class="content">
-        {{& journey.content}}
-      </div>
+      <div class="content">{{& journey.content}}</div>
 
       <ul class="summary">
         {{#each itinerary}}
@@ -66,11 +64,10 @@ parent: feed
             {{count views '' '(Eine Ansicht)' '(# Ansichten)'}}
             {{> partials/weather in=.}}
           </div>
-          {{> partials/images in=.}}
 
-          <div class="content">
-            {{& content}}
-          </div>
+          <div class="content">{{& content}}</div>
+
+          {{> partials/images in=.}}
         </section>
       {{/each}}
     {{else}}

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -542,6 +542,10 @@
         padding-bottom: 1rem;
       }
 
+      &.is-empty {
+        display: none;
+      }
+
       &.all, &.is-single, &.is-preview {
         grid-template-columns: 1fr;
       }

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -538,8 +538,7 @@
       overflow: hidden;
 
       &.overview {
-        grid-template-columns: 1fr 1fr 1fr 1fr;
-        padding-bottom: 1rem;
+        grid-template-columns: repeat(4, 1fr);
       }
 
       &.is-empty {

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -796,7 +796,7 @@
       }
 
       .images.overview {
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: repeat(2, 1fr);
       }
 
       .cover h1 {


### PR DESCRIPTION
This pull request changes the order to be title, metadata, text and images instead of images and text. Readers may prefer to know the story first before diving into the images. Requested by @kiesel

## Implementation

* [x] In journeys
* [x] In feed

A content element's text was already displayed above the images.

## Before

![Screenshot before](https://github.com/user-attachments/assets/5e6b8d6b-3b3d-4de9-89a4-1f884089daf5)

## After

![Screenshot after](https://github.com/user-attachments/assets/2fc99bfa-b449-4699-9c8b-8bcaf68d9bf7)

