### PR TITLE
Explicitely set map interactions

### DIFF
--- a/src/main/handlebars/content.handlebars
+++ b/src/main/handlebars/content.handlebars
@@ -27,7 +27,7 @@ parent: feed
         {{count item.views '' '(Eine Ansicht)' '(# Ansichten)'}}
       </div>
 
-      <div id="map" tabindex="1">
+      <div id="map">
         <div class="popup"></div>
       </div>
 

--- a/src/main/handlebars/content.handlebars
+++ b/src/main/handlebars/content.handlebars
@@ -27,7 +27,7 @@ parent: feed
         {{count item.views '' '(Eine Ansicht)' '(# Ansichten)'}}
       </div>
 
-      <div id="map">
+      <div id="map" tabindex="0">
         <div class="popup"></div>
       </div>
 

--- a/src/main/handlebars/journey.handlebars
+++ b/src/main/handlebars/journey.handlebars
@@ -29,7 +29,7 @@ parent: feed
       </div>
       {{> partials/images in=journey first='true' style='overview'}}
 
-      <div id="map">
+      <div id="map" tabindex="0">
         <div class="popup"></div>
       </div>
 

--- a/src/main/handlebars/journey.handlebars
+++ b/src/main/handlebars/journey.handlebars
@@ -29,7 +29,7 @@ parent: feed
       </div>
       {{> partials/images in=journey first='true' style='overview'}}
 
-      <div id="map" tabindex="1">
+      <div id="map">
         <div class="popup"></div>
       </div>
 

--- a/src/main/handlebars/journeys.handlebars
+++ b/src/main/handlebars/journeys.handlebars
@@ -11,7 +11,7 @@
     {{/with}}
   {{/inline}}
   {{#*inline "main"}}
-    <div id="map" class="full">
+    <div id="map" class="full" tabindex="0">
       <div class="popup"></div>
     </div>
 

--- a/src/main/handlebars/journeys.handlebars
+++ b/src/main/handlebars/journeys.handlebars
@@ -11,7 +11,7 @@
     {{/with}}
   {{/inline}}
   {{#*inline "main"}}
-    <div id="map" class="full" tabindex="1">
+    <div id="map" class="full">
       <div class="popup"></div>
     </div>
 

--- a/src/main/js/mapping.js
+++ b/src/main/js/mapping.js
@@ -37,7 +37,9 @@ class Mapping {
       interactions: [
         new ol.interaction.DragPan(),
         new ol.interaction.PinchZoom(),
-        new ol.interaction.MouseWheelZoom({condition: event => event.originalEvent.ctrlKey})
+        new ol.interaction.MouseWheelZoom({condition: event => event.originalEvent.ctrlKey}),
+        new ol.interaction.KeyboardPan(),
+        new ol.interaction.KeyboardZoom(),
       ],
       target: $element,
       layers: [new ol.layer.Tile({source: new ol.source.OSM()})]

--- a/src/main/js/mapping.js
+++ b/src/main/js/mapping.js
@@ -28,12 +28,17 @@ class Mapping {
 
   /** Escape input for use in HTML */
   html(input) {
-    return input.replace(/[<>&]/g, c => '&#' + c.charCodeAt(0) + ';');
+    return input?.replace(/[<>&]/g, c => '&#' + c.charCodeAt(0) + ';');
   }
 
   /** Project this map on to a given DOM element */
   project($element, connect) {
     const map = new ol.Map({
+      interactions: [
+        new ol.interaction.DragPan(),
+        new ol.interaction.PinchZoom(),
+        new ol.interaction.MouseWheelZoom({condition: event => event.originalEvent.ctrlKey})
+      ],
       target: $element,
       layers: [new ol.layer.Tile({source: new ol.source.OSM()})]
     });


### PR DESCRIPTION
This pull request revises the solution found in #64 which also prevents moving the map using touch without previously having to focus the map (e.g. by touching it or clicking) and overwriting the default map interactions (*see below*) as follows:

## Touch

* [x] Swipe to move
* [x] Pinch to zoom 

## Mouse / trackpad

* [x] Ctrl + mouse wheel to zoom (*default: mouse wheel zooms*)
* [x] Drag to move  

Rotating the map is disabled.

## Keyboard (on focus)

* [x] Arrow keys to pan
* [x] `+` and `-` to zoom in and out

* * * 

The default set of interactions, in sequence, is: 

* DragRotate
* DoubleClickZoom
* DragPan
* PinchRotate
* PinchZoom
* KeyboardPan
* KeyboardZoom
* MouseWheelZoom
* DragZoom

See https://openlayers.org/en/latest/apidoc/module-ol_interaction_defaults